### PR TITLE
非推奨のgetResponseTime()をelapsedTimeに置き換え

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ export default async function () {
 
     app.addHook('onResponse', (req, res) => {
         if (!(req.method === 'GET' || req.method === 'HEAD')) return
-        console.info(`${req.method} ${res.statusCode} ${req.url} (${res.getResponseTime()}ms)`)
+        console.info(`${req.method} ${res.statusCode} ${req.url} (${res.elapsedTime}ms)`)
     })
 
     app.listen({


### PR DESCRIPTION
DeprecationWarning: You are using the deprecated "reply.getResponseTime()" method. Use the "reply.elapsedTime" property instead. Method "reply.getResponseTime()" will be removed in `fastify@5`. とのことでした。
（初プルリクです…！）